### PR TITLE
fix(wasm): stack size and iterative BSP collect for large CSG meshes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,9 +37,12 @@ if(EMSCRIPTEN)
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/wasmbuild"
   )
   # Keep in sync with src/include/wasmgl_exports.h
+  # BSP/CSG recursion can run very deep on large meshes; default wasm stack is small and
+  # overflows manifest as uncaught RuntimeError: memory access out of bounds.
   target_link_options(wasmgl PRIVATE
     "SHELL:-sUSE_GLFW=3"
     "SHELL:-sMIN_WEBGL_VERSION=2"
+    "SHELL:-sSTACK_SIZE=33554432"
     "SHELL:-sALLOW_MEMORY_GROWTH=1"
     "SHELL:-sEXPORTED_FUNCTIONS=[_main,_addCube,_addSphere,_cameraZoomIn,_cameraZoomOut,_cameraNudgeViewYawDegrees,_cameraNudgeViewPitchDegrees,_cameraNudgePositionView,_getSceneObjectCount,_setSelectedObjectIndex,_getSelectedObjectIndex,_getObjectKind,_getSelectedBoxWidth,_getSelectedBoxHeight,_getSelectedBoxDepth,_getSelectedSphereRadius,_getSelectedSphereWidthSegments,_getSelectedSphereHeightSegments,_resizeSelectedBox,_resizeSelectedSphere,_nudgeSelectedTranslate,_nudgeSelectedRotateDegrees,_setBooleanOperandA,_setBooleanOperandB,_getBooleanOperandA,_getBooleanOperandB,_performBooleanUnion,_performBooleanDifference,_performBooleanIntersection]"
   )

--- a/src/threecsg/node.cpp
+++ b/src/threecsg/node.cpp
@@ -86,11 +86,20 @@ void Node::build(vector<shared_ptr<Polygon>> const &polygons)
 
 void Node::collectPolygons(vector<shared_ptr<Polygon>> &out) const
 {
-  out.insert(out.end(), this->polygons.begin(), this->polygons.end());
-  if (this->front)
-    this->front->collectPolygons(out);
-  if (this->back)
-    this->back->collectPolygons(out);
+  /** Iterative preorder (polygons at node, then front subtree, then back) avoids deep
+   *  recursion on tall BSP trees — same order as the prior recursive implementation. */
+  vector<Node const *> stack;
+  stack.push_back(this);
+  while (!stack.empty())
+  {
+    Node const *n = stack.back();
+    stack.pop_back();
+    out.insert(out.end(), n->polygons.begin(), n->polygons.end());
+    if (n->back)
+      stack.push_back(n->back.get());
+    if (n->front)
+      stack.push_back(n->front.get());
+  }
 }
 
 vector<shared_ptr<Polygon>> Node::allPolygons() const


### PR DESCRIPTION
## Problem
Large meshes (big boxes, high-segment spheres) can trigger `RuntimeError: memory access out of bounds` in the browser. Deep BSP / CSG recursion can overflow the default WebAssembly stack.

## Changes
- **`-sSTACK_SIZE=33554432` (32 MiB)** in the Emscripten link flags for the wasm target.
- **`Node::collectPolygons`**: iterative preorder walk (same polygon order as the previous recursive version) to avoid one deep recursive path when flattening tall BSP trees.

## Notes
- Rebuild wasm with `./compileWasm.sh` after pull.
- If issues persist on extreme geometry, the next step is further increasing `STACK_SIZE` or reducing recursion in `clipPolygons` / `clipTo`.

Made with [Cursor](https://cursor.com)