### PR TITLE
Three.js–aligned primitives and robust CSG (WASM)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,10 @@ set(WASMGL_SOURCES
   src/core/functions.cpp
   src/core/mesh.cpp
   src/primitives/box.cpp
+  src/primitives/cylinder.cpp
   src/primitives/pyramid.cpp
   src/primitives/sphere.cpp
+  src/primitives/torus.cpp
   src/shaders/shader.cpp
   src/threecsg/node.cpp
   src/threecsg/polygon.cpp
@@ -44,7 +46,7 @@ if(EMSCRIPTEN)
     "SHELL:-sMIN_WEBGL_VERSION=2"
     "SHELL:-sSTACK_SIZE=33554432"
     "SHELL:-sALLOW_MEMORY_GROWTH=1"
-    "SHELL:-sEXPORTED_FUNCTIONS=[_main,_addCube,_addSphere,_cameraZoomIn,_cameraZoomOut,_cameraNudgeViewYawDegrees,_cameraNudgeViewPitchDegrees,_cameraNudgePositionView,_getSceneObjectCount,_setSelectedObjectIndex,_getSelectedObjectIndex,_getObjectKind,_getSelectedBoxWidth,_getSelectedBoxHeight,_getSelectedBoxDepth,_getSelectedSphereRadius,_getSelectedSphereWidthSegments,_getSelectedSphereHeightSegments,_resizeSelectedBox,_resizeSelectedSphere,_nudgeSelectedTranslate,_nudgeSelectedRotateDegrees,_setBooleanOperandA,_setBooleanOperandB,_getBooleanOperandA,_getBooleanOperandB,_performBooleanUnion,_performBooleanDifference,_performBooleanIntersection]"
+    "SHELL:-sEXPORTED_FUNCTIONS=[_main,_addCube,_addSphere,_addPyramid,_addCylinder,_addTorus,_cameraZoomIn,_cameraZoomOut,_cameraNudgeViewYawDegrees,_cameraNudgeViewPitchDegrees,_cameraNudgePositionView,_getSceneObjectCount,_setSelectedObjectIndex,_getSelectedObjectIndex,_getObjectKind,_getSelectedBoxWidth,_getSelectedBoxHeight,_getSelectedBoxDepth,_getSelectedSphereRadius,_getSelectedSphereWidthSegments,_getSelectedSphereHeightSegments,_getSelectedPyramidSide,_getSelectedPyramidHeight,_getSelectedCylinderRadiusBottom,_getSelectedCylinderRadiusTop,_getSelectedCylinderHeight,_getSelectedCylinderRadialSegments,_getSelectedCylinderHeightSegments,_getSelectedTorusMajorRadius,_getSelectedTorusMinorRadius,_getSelectedTorusRadialSegments,_getSelectedTorusTubularSegments,_resizeSelectedBox,_resizeSelectedSphere,_resizeSelectedPyramid,_resizeSelectedCylinder,_resizeSelectedTorus,_nudgeSelectedTranslate,_nudgeSelectedRotateDegrees,_setBooleanOperandA,_setBooleanOperandB,_getBooleanOperandA,_getBooleanOperandB,_performBooleanUnion,_performBooleanDifference,_performBooleanIntersection]"
   )
 else()
   find_package(OpenGL REQUIRED)

--- a/src/core/functions.cpp
+++ b/src/core/functions.cpp
@@ -16,6 +16,27 @@ std::shared_ptr<Sphere> createSphere(SphereDimensions const &dimensions, SphereP
   return mesh;
 }
 
+std::shared_ptr<Pyramid> createPyramid(PyramidDimensions const &dimensions)
+{
+  auto mesh = std::make_shared<Pyramid>(dimensions);
+  mesh->computeThreeBSP();
+  return mesh;
+}
+
+std::shared_ptr<Cylinder> createCylinder(CylinderDimensions const &dimensions, CylinderParameters const &parameters)
+{
+  auto mesh = std::make_shared<Cylinder>(dimensions, parameters);
+  mesh->computeThreeBSP();
+  return mesh;
+}
+
+std::shared_ptr<Torus> createTorus(TorusDimensions const &dimensions, TorusParameters const &parameters)
+{
+  auto mesh = std::make_shared<Torus>(dimensions, parameters);
+  mesh->computeThreeBSP();
+  return mesh;
+}
+
 std::shared_ptr<Mesh> rotate(std::shared_ptr<Mesh> const &mesh, glm::vec3 const &rotation)
 {
   mesh->rotate(rotation);

--- a/src/core/functions.h
+++ b/src/core/functions.h
@@ -5,11 +5,17 @@
 #include "mesh.h"
 #include "../primitives/box.h"
 #include "../primitives/sphere.h"
+#include "../primitives/pyramid.h"
+#include "../primitives/cylinder.h"
+#include "../primitives/torus.h"
 
 using namespace std;
 
 std::shared_ptr<Box> createBox(BoxDimensions const &dimensions);
 std::shared_ptr<Sphere> createSphere(SphereDimensions const &dimensions, SphereParameters const &parameters);
+std::shared_ptr<Pyramid> createPyramid(PyramidDimensions const &dimensions);
+std::shared_ptr<Cylinder> createCylinder(CylinderDimensions const &dimensions, CylinderParameters const &parameters);
+std::shared_ptr<Torus> createTorus(TorusDimensions const &dimensions, TorusParameters const &parameters);
 
 std::shared_ptr<Mesh> rotate(std::shared_ptr<Mesh> const &mesh, glm::vec3 const &rotation);
 std::shared_ptr<Mesh> translate(std::shared_ptr<Mesh> const &mesh, glm::vec3 const &translation);

--- a/src/include/wasmgl_exports.h
+++ b/src/include/wasmgl_exports.h
@@ -4,8 +4,7 @@
  * Keep this list in sync with CMake Emscripten flags:
  *   -sEXPORTED_FUNCTIONS=[_main,_addCube,...]
  *
- * From JS (classic shell script): after load, call via Module._addCube(...) inside
- * Module.onRuntimeInitialized so GL + wasm are ready.
+ * Object kind (getObjectKind): 0 unknown, 1 cube, 2 sphere, 3 CSG, 4 pyramid, 5 cylinder, 6 torus.
  */
 
 #ifndef WASMGL_EXPORTS_H
@@ -22,35 +21,49 @@
 extern "C" {
 #endif
 
-/** Adds an axis-aligned box: full width, height, depth in world units (see createBox). */
 WASMGL_KEEP void addCube(float width, float height, float depth);
-
-/** UV sphere: radius, segment counts (clamped: width ≥ 3, height ≥ 2). */
 WASMGL_KEEP void addSphere(float radius, int widthSeg, int heightSeg);
+/** Equilateral triangular base; `side` = base edge length. */
+WASMGL_KEEP void addPyramid(float side, float height);
+/** Y-axis cylinder / truncated cylinder; equal radii = right cylinder. */
+WASMGL_KEEP void addCylinder(float radiusBottom, float radiusTop, float height, int radialSeg, int heightSeg);
+/** Ring in XY plane; major = hole-to-tube-center, minor = tube radius. */
+WASMGL_KEEP void addTorus(float majorRadius, float minorRadius, int radialSeg, int tubularSeg);
 
 WASMGL_KEEP void cameraZoomOut(void);
 WASMGL_KEEP void cameraZoomIn(void);
 WASMGL_KEEP void cameraNudgeViewYawDegrees(float deltaDeg);
 WASMGL_KEEP void cameraNudgeViewPitchDegrees(float deltaDeg);
-/** Pan / dolly camera in view space: forward, right (strafe), up — world units per step. */
 WASMGL_KEEP void cameraNudgePositionView(float alongFront, float alongRight, float alongUp);
 
 WASMGL_KEEP int getSceneObjectCount(void);
 WASMGL_KEEP void setSelectedObjectIndex(int idx);
 WASMGL_KEEP int getSelectedObjectIndex(void);
-/** 0 unknown, 1 cube, 2 sphere, 3 CSG result — for UI labels. */
 WASMGL_KEEP int getObjectKind(int index);
 
-/** Read selected mesh dimensions; 0 if not a box / not selected. */
 WASMGL_KEEP float getSelectedBoxWidth(void);
 WASMGL_KEEP float getSelectedBoxHeight(void);
 WASMGL_KEEP float getSelectedBoxDepth(void);
 WASMGL_KEEP float getSelectedSphereRadius(void);
 WASMGL_KEEP int getSelectedSphereWidthSegments(void);
 WASMGL_KEEP int getSelectedSphereHeightSegments(void);
-/** Rebuild selected box or sphere from new parameters (no-op for CSG or wrong type). */
+WASMGL_KEEP float getSelectedPyramidSide(void);
+WASMGL_KEEP float getSelectedPyramidHeight(void);
+WASMGL_KEEP float getSelectedCylinderRadiusBottom(void);
+WASMGL_KEEP float getSelectedCylinderRadiusTop(void);
+WASMGL_KEEP float getSelectedCylinderHeight(void);
+WASMGL_KEEP int getSelectedCylinderRadialSegments(void);
+WASMGL_KEEP int getSelectedCylinderHeightSegments(void);
+WASMGL_KEEP float getSelectedTorusMajorRadius(void);
+WASMGL_KEEP float getSelectedTorusMinorRadius(void);
+WASMGL_KEEP int getSelectedTorusRadialSegments(void);
+WASMGL_KEEP int getSelectedTorusTubularSegments(void);
+
 WASMGL_KEEP void resizeSelectedBox(float width, float height, float depth);
 WASMGL_KEEP void resizeSelectedSphere(float radius, int widthSeg, int heightSeg);
+WASMGL_KEEP void resizeSelectedPyramid(float side, float height);
+WASMGL_KEEP void resizeSelectedCylinder(float radiusBottom, float radiusTop, float height, int radialSeg, int heightSeg);
+WASMGL_KEEP void resizeSelectedTorus(float majorRadius, float minorRadius, int radialSeg, int tubularSeg);
 
 WASMGL_KEEP void nudgeSelectedTranslate(float dx, float dy, float dz);
 WASMGL_KEEP void nudgeSelectedRotateDegrees(float rxDeg, float ryDeg, float rzDeg);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,9 @@
 #include "core/mesh.h"
 #include "primitives/box.h"
 #include "primitives/sphere.h"
+#include "primitives/pyramid.h"
+#include "primitives/cylinder.h"
+#include "primitives/torus.h"
 
 #include "./core/functions.h"
 #include "wasmgl_exports.h"
@@ -34,7 +37,7 @@
 
 Window mainWindow;
 std::vector<std::shared_ptr<Mesh>> meshList;
-/** Per-object label for UI: 1 = cube, 2 = sphere, 3 = CSG result (see wasmgl_exports.h). */
+/** UI labels: 1 cube, 2 sphere, 3 CSG, 4 pyramid, 5 cylinder, 6 torus (wasmgl_exports.h). */
 std::vector<int> meshObjectKinds;
 static int g_selectedIndex{-1};
 /** Indices for constructive solid ops (union / subtract / intersect). Must differ. */
@@ -309,6 +312,43 @@ void addSphere(float radius, int widthSeg, int heightSeg)
 	g_selectedIndex = static_cast<int>(meshList.size()) - 1;
 }
 
+void addPyramid(float side, float height)
+{
+	GLfloat const s = std::max(1e-4f, side);
+	GLfloat const h = std::max(1e-4f, height);
+	auto pyr = createPyramid(PyramidDimensions{s, h});
+	pyr->setSolidColor(glm::vec3(0.75f, 0.55f, 0.22f));
+	meshList.push_back(pyr);
+	meshObjectKinds.push_back(4);
+	g_selectedIndex = static_cast<int>(meshList.size()) - 1;
+}
+
+void addCylinder(float radiusBottom, float radiusTop, float height, int radialSeg, int heightSeg)
+{
+	int const rseg = std::max(3, radialSeg);
+	int const hseg = std::max(1, heightSeg);
+	auto cyl = createCylinder(
+			CylinderDimensions{std::max(1e-4f, radiusBottom), std::max(1e-4f, radiusTop), std::max(1e-4f, height)},
+			CylinderParameters{rseg, hseg});
+	cyl->setSolidColor(glm::vec3(0.24f, 0.78f, 0.45f));
+	meshList.push_back(cyl);
+	meshObjectKinds.push_back(5);
+	g_selectedIndex = static_cast<int>(meshList.size()) - 1;
+}
+
+void addTorus(float majorRadius, float minorRadius, int radialSeg, int tubularSeg)
+{
+	int const rs = std::max(3, radialSeg);
+	int const ts = std::max(3, tubularSeg);
+	auto t = createTorus(
+			TorusDimensions{std::max(1e-4f, majorRadius), std::max(1e-4f, minorRadius)},
+			TorusParameters{rs, ts});
+	t->setSolidColor(glm::vec3(0.72f, 0.38f, 0.88f));
+	meshList.push_back(t);
+	meshObjectKinds.push_back(6);
+	g_selectedIndex = static_cast<int>(meshList.size()) - 1;
+}
+
 int getSceneObjectCount(void)
 {
 	return static_cast<int>(meshList.size());
@@ -428,6 +468,161 @@ void resizeSelectedSphere(float radius, int widthSeg, int heightSeg)
 	p.heightSegments = hs;
 	s->setParameters(p);
 	s->rebuildGeometry();
+}
+
+float getSelectedPyramidSide(void)
+{
+	if (g_selectedIndex < 0 || g_selectedIndex >= static_cast<int>(meshList.size()))
+		return 0.0f;
+	auto p = std::dynamic_pointer_cast<Pyramid>(meshList[static_cast<size_t>(g_selectedIndex)]);
+	if (!p)
+		return 0.0f;
+	return p->getDimensions().side;
+}
+
+float getSelectedPyramidHeight(void)
+{
+	if (g_selectedIndex < 0 || g_selectedIndex >= static_cast<int>(meshList.size()))
+		return 0.0f;
+	auto p = std::dynamic_pointer_cast<Pyramid>(meshList[static_cast<size_t>(g_selectedIndex)]);
+	if (!p)
+		return 0.0f;
+	return p->getDimensions().height;
+}
+
+void resizeSelectedPyramid(float side, float height)
+{
+	if (g_selectedIndex < 0 || g_selectedIndex >= static_cast<int>(meshList.size()))
+		return;
+	auto p = std::dynamic_pointer_cast<Pyramid>(meshList[static_cast<size_t>(g_selectedIndex)]);
+	if (!p)
+		return;
+	p->setDimensions(PyramidDimensions{std::max(1e-4f, side), std::max(1e-4f, height)});
+	p->rebuildGeometry();
+}
+
+float getSelectedCylinderRadiusBottom(void)
+{
+	if (g_selectedIndex < 0 || g_selectedIndex >= static_cast<int>(meshList.size()))
+		return 0.0f;
+	auto c = std::dynamic_pointer_cast<Cylinder>(meshList[static_cast<size_t>(g_selectedIndex)]);
+	if (!c)
+		return 0.0f;
+	return c->getDimensions().radiusBottom;
+}
+
+float getSelectedCylinderRadiusTop(void)
+{
+	if (g_selectedIndex < 0 || g_selectedIndex >= static_cast<int>(meshList.size()))
+		return 0.0f;
+	auto c = std::dynamic_pointer_cast<Cylinder>(meshList[static_cast<size_t>(g_selectedIndex)]);
+	if (!c)
+		return 0.0f;
+	return c->getDimensions().radiusTop;
+}
+
+float getSelectedCylinderHeight(void)
+{
+	if (g_selectedIndex < 0 || g_selectedIndex >= static_cast<int>(meshList.size()))
+		return 0.0f;
+	auto c = std::dynamic_pointer_cast<Cylinder>(meshList[static_cast<size_t>(g_selectedIndex)]);
+	if (!c)
+		return 0.0f;
+	return c->getDimensions().height;
+}
+
+int getSelectedCylinderRadialSegments(void)
+{
+	if (g_selectedIndex < 0 || g_selectedIndex >= static_cast<int>(meshList.size()))
+		return 0;
+	auto c = std::dynamic_pointer_cast<Cylinder>(meshList[static_cast<size_t>(g_selectedIndex)]);
+	if (!c)
+		return 0;
+	return c->getParameters().radialSegments;
+}
+
+int getSelectedCylinderHeightSegments(void)
+{
+	if (g_selectedIndex < 0 || g_selectedIndex >= static_cast<int>(meshList.size()))
+		return 0;
+	auto c = std::dynamic_pointer_cast<Cylinder>(meshList[static_cast<size_t>(g_selectedIndex)]);
+	if (!c)
+		return 0;
+	return c->getParameters().heightSegments;
+}
+
+void resizeSelectedCylinder(float radiusBottom, float radiusTop, float height, int radialSeg, int heightSeg)
+{
+	if (g_selectedIndex < 0 || g_selectedIndex >= static_cast<int>(meshList.size()))
+		return;
+	auto c = std::dynamic_pointer_cast<Cylinder>(meshList[static_cast<size_t>(g_selectedIndex)]);
+	if (!c)
+		return;
+	int const rseg = std::max(3, radialSeg);
+	int const hseg = std::max(1, heightSeg);
+	c->setDimensions(CylinderDimensions{std::max(1e-4f, radiusBottom), std::max(1e-4f, radiusTop), std::max(1e-4f, height)});
+	CylinderParameters p = c->getParameters();
+	p.radialSegments = rseg;
+	p.heightSegments = hseg;
+	c->setParameters(p);
+	c->rebuildGeometry();
+}
+
+float getSelectedTorusMajorRadius(void)
+{
+	if (g_selectedIndex < 0 || g_selectedIndex >= static_cast<int>(meshList.size()))
+		return 0.0f;
+	auto t = std::dynamic_pointer_cast<Torus>(meshList[static_cast<size_t>(g_selectedIndex)]);
+	if (!t)
+		return 0.0f;
+	return t->getDimensions().majorRadius;
+}
+
+float getSelectedTorusMinorRadius(void)
+{
+	if (g_selectedIndex < 0 || g_selectedIndex >= static_cast<int>(meshList.size()))
+		return 0.0f;
+	auto t = std::dynamic_pointer_cast<Torus>(meshList[static_cast<size_t>(g_selectedIndex)]);
+	if (!t)
+		return 0.0f;
+	return t->getDimensions().minorRadius;
+}
+
+int getSelectedTorusRadialSegments(void)
+{
+	if (g_selectedIndex < 0 || g_selectedIndex >= static_cast<int>(meshList.size()))
+		return 0;
+	auto t = std::dynamic_pointer_cast<Torus>(meshList[static_cast<size_t>(g_selectedIndex)]);
+	if (!t)
+		return 0;
+	return t->getParameters().radialSegments;
+}
+
+int getSelectedTorusTubularSegments(void)
+{
+	if (g_selectedIndex < 0 || g_selectedIndex >= static_cast<int>(meshList.size()))
+		return 0;
+	auto t = std::dynamic_pointer_cast<Torus>(meshList[static_cast<size_t>(g_selectedIndex)]);
+	if (!t)
+		return 0;
+	return t->getParameters().tubularSegments;
+}
+
+void resizeSelectedTorus(float majorRadius, float minorRadius, int radialSeg, int tubularSeg)
+{
+	if (g_selectedIndex < 0 || g_selectedIndex >= static_cast<int>(meshList.size()))
+		return;
+	auto t = std::dynamic_pointer_cast<Torus>(meshList[static_cast<size_t>(g_selectedIndex)]);
+	if (!t)
+		return;
+	int const rs = std::max(3, radialSeg);
+	int const ts = std::max(3, tubularSeg);
+	t->setDimensions(TorusDimensions{std::max(1e-4f, majorRadius), std::max(1e-4f, minorRadius)});
+	TorusParameters p = t->getParameters();
+	p.radialSegments = rs;
+	p.tubularSegments = ts;
+	t->setParameters(p);
+	t->rebuildGeometry();
 }
 
 void nudgeSelectedTranslate(float dx, float dy, float dz)

--- a/src/primitives/box.cpp
+++ b/src/primitives/box.cpp
@@ -1,13 +1,83 @@
 #include "box.h"
 #include <iostream>
 #include <math.h>
+#include <vector>
 #include "../threecsg/threebsp.h"
+
+namespace
+{
+	int axisOf(char c)
+	{
+		return c == 'x' ? 0 : (c == 'y' ? 1 : 2);
+	}
+	void setComp(glm::vec3 &p, int a, float val)
+	{
+		if (a == 0)
+			p.x = val;
+		else if (a == 1)
+			p.y = val;
+		else
+			p.z = val;
+	}
+
+	/** Mirrors `buildPlane` in Three.js `src/geometries/BoxGeometry.js` (r162). */
+	void buildPlane(char u, char v, char w, float udir, float vdir,
+									float width, float height, float depth,
+									int gridX, int gridY,
+									std::vector<glm::vec3> &vertices, std::vector<int> &indices)
+	{
+		float const segmentWidth = width / static_cast<float>(gridX);
+		float const segmentHeight = height / static_cast<float>(gridY);
+		float const widthHalf = width * 0.5f;
+		float const heightHalf = height * 0.5f;
+		float const depthHalf = depth * 0.5f;
+		int const gridX1 = gridX + 1;
+		int const gridY1 = gridY + 1;
+
+		int const U = axisOf(u);
+		int const V = axisOf(v);
+		int const W = axisOf(w);
+
+		int const numberOfVertices = static_cast<int>(vertices.size());
+
+		for (int iy = 0; iy < gridY1; ++iy)
+		{
+			float const y = iy * segmentHeight - heightHalf;
+			for (int ix = 0; ix < gridX1; ++ix)
+			{
+				float const x = ix * segmentWidth - widthHalf;
+				glm::vec3 vector(0.0f);
+				setComp(vector, U, x * udir);
+				setComp(vector, V, y * vdir);
+				setComp(vector, W, depthHalf);
+				vertices.push_back(vector);
+			}
+		}
+
+		for (int iy = 0; iy < gridY; ++iy)
+		{
+			for (int ix = 0; ix < gridX; ++ix)
+			{
+				int const a = numberOfVertices + ix + gridX1 * iy;
+				int const b = numberOfVertices + ix + gridX1 * (iy + 1);
+				int const c = numberOfVertices + (ix + 1) + gridX1 * (iy + 1);
+				int const d = numberOfVertices + (ix + 1) + gridX1 * iy;
+				indices.push_back(a);
+				indices.push_back(b);
+				indices.push_back(d);
+				indices.push_back(b);
+				indices.push_back(c);
+				indices.push_back(d);
+			}
+		}
+	}
+}
 
 Box::Box(BoxDimensions dimensions) : Mesh{}, dimensions{dimensions}
 {
-  createVertices();
-  computeFaces();
-  createMesh();
+	createVertices();
+	computeFaces();
+	createMesh();
 }
 
 Box::~Box()
@@ -30,28 +100,22 @@ void Box::rebuildGeometry()
 
 void Box::createVertices()
 {
+	float const w = std::max(1e-4f, dimensions.width);
+	float const h = std::max(1e-4f, dimensions.height);
+	float const d = std::max(1e-4f, dimensions.depth);
+	/** Default segment counts == `new THREE.BoxGeometry(w,h,d)` (1,1,1). */
+	int const widthSegments = 1;
+	int const heightSegments = 1;
+	int const depthSegments = 1;
 
-  indices = {
-      0, 2, 1,
-      2, 3, 1,
-      4, 6, 5,
-      6, 7, 5,
-      4, 5, 1,
-      5, 0, 1,
-      7, 6, 2,
-      6, 3, 2,
-      5, 7, 0,
-      7, 2, 0,
-      1, 3, 4,
-      3, 6, 4};
+	vertices.clear();
+	indices.clear();
 
-  vertices = {
-      {dimensions.width / 2, dimensions.height / 2, dimensions.depth / 2},
-      {dimensions.width / 2, dimensions.height / 2, -dimensions.depth / 2},
-      {dimensions.width / 2, -dimensions.height / 2, dimensions.depth / 2},
-      {dimensions.width / 2, -dimensions.height / 2, -dimensions.depth / 2},
-      {-dimensions.width / 2, dimensions.height / 2, -dimensions.depth / 2},
-      {-dimensions.width / 2, dimensions.height / 2, dimensions.depth / 2},
-      {-dimensions.width / 2, -dimensions.height / 2, -dimensions.depth / 2},
-      {-dimensions.width / 2, -dimensions.height / 2, dimensions.depth / 2}};
+	/** Same face order and `buildPlane` args as Three.js `BoxGeometry`. */
+	buildPlane('z', 'y', 'x', -1.0f, -1.0f, d, h, w, depthSegments, heightSegments, vertices, indices);
+	buildPlane('z', 'y', 'x', 1.0f, -1.0f, d, h, -w, depthSegments, heightSegments, vertices, indices);
+	buildPlane('x', 'z', 'y', 1.0f, 1.0f, w, d, h, widthSegments, depthSegments, vertices, indices);
+	buildPlane('x', 'z', 'y', 1.0f, -1.0f, w, d, -h, widthSegments, depthSegments, vertices, indices);
+	buildPlane('x', 'y', 'z', 1.0f, -1.0f, w, h, d, widthSegments, heightSegments, vertices, indices);
+	buildPlane('x', 'y', 'z', -1.0f, -1.0f, w, h, -d, widthSegments, heightSegments, vertices, indices);
 }

--- a/src/primitives/cylinder.cpp
+++ b/src/primitives/cylinder.cpp
@@ -1,0 +1,161 @@
+#include "cylinder.h"
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+Cylinder::Cylinder(CylinderDimensions const &dimensions, CylinderParameters const &parameters)
+		: Mesh{}, dimensions{dimensions}, parameters{parameters}
+{
+	createVertices();
+	computeFaces();
+	createMesh();
+}
+
+Cylinder::~Cylinder() = default;
+
+void Cylinder::rebuildGeometry()
+{
+	ClearMesh();
+	vertices.clear();
+	normals.clear();
+	faces.clear();
+	indices.clear();
+	createVertices();
+	computeFaces();
+	createMesh();
+	threeBSPDone = false;
+	computeThreeBSP();
+}
+
+void Cylinder::createVertices()
+{
+	/** Three.js `CylinderGeometry` (r162): `radiusTop`, `radiusBottom`, height, radialSegments, heightSegments,
+	 *  openEnded=false, thetaStart=0, thetaLength=2π */
+	int const radialSegments = std::max(3, parameters.radialSegments);
+	int const heightSegments = std::max(1, parameters.heightSegments);
+	float const radiusTop = std::max(1e-4f, dimensions.radiusTop);
+	float const radiusBottom = std::max(1e-4f, dimensions.radiusBottom);
+	float const height = std::max(1e-4f, dimensions.height);
+	float const thetaStart = 0.0f;
+	float const thetaLength = static_cast<float>(2.0 * M_PI);
+
+	float const halfHeight = height * 0.5f;
+	float const slope = (radiusBottom - radiusTop) / height;
+
+	std::vector<std::vector<int>> indexArray;
+
+	vertices.clear();
+	indices.clear();
+
+	int index = 0;
+
+	auto generateTorso = [&]()
+	{
+		for (int y = 0; y <= heightSegments; ++y)
+		{
+			std::vector<int> indexRow;
+			float const v = static_cast<float>(y) / static_cast<float>(heightSegments);
+			float const radius = v * (radiusBottom - radiusTop) + radiusTop;
+
+			for (int x = 0; x <= radialSegments; ++x)
+			{
+				float const u = static_cast<float>(x) / static_cast<float>(radialSegments);
+				float const theta = u * thetaLength + thetaStart;
+				float const sinTheta = std::sin(theta);
+				float const cosTheta = std::cos(theta);
+
+				glm::vec3 vertex;
+				vertex.x = radius * sinTheta;
+				vertex.y = -v * height + halfHeight;
+				vertex.z = radius * cosTheta;
+				vertices.push_back(vertex);
+
+				glm::vec3 normal(sinTheta, slope, cosTheta);
+				normal = glm::normalize(normal);
+				normals.push_back(normal);
+
+				indexRow.push_back(index++);
+			}
+			indexArray.push_back(std::move(indexRow));
+		}
+
+		for (int x = 0; x < radialSegments; ++x)
+		{
+			for (int y = 0; y < heightSegments; ++y)
+			{
+				int const a = indexArray[y][x];
+				int const b = indexArray[y + 1][x];
+				int const c = indexArray[y + 1][x + 1];
+				int const d = indexArray[y][x + 1];
+				indices.push_back(static_cast<unsigned int>(a));
+				indices.push_back(static_cast<unsigned int>(b));
+				indices.push_back(static_cast<unsigned int>(d));
+				indices.push_back(static_cast<unsigned int>(b));
+				indices.push_back(static_cast<unsigned int>(c));
+				indices.push_back(static_cast<unsigned int>(d));
+			}
+		}
+	};
+
+	auto generateCap = [&](bool top)
+	{
+		int const centerIndexStart = index;
+
+		float const radius = top ? radiusTop : radiusBottom;
+		float const sign = top ? 1.0f : -1.0f;
+
+		for (int x = 1; x <= radialSegments; ++x)
+		{
+			vertices.push_back(glm::vec3(0.0f, halfHeight * sign, 0.0f));
+			normals.push_back(glm::vec3(0.0f, sign, 0.0f));
+			++index;
+		}
+
+		int const centerIndexEnd = index;
+
+		for (int x = 0; x <= radialSegments; ++x)
+		{
+			float const u = static_cast<float>(x) / static_cast<float>(radialSegments);
+			float const theta = u * thetaLength + thetaStart;
+			float const cosTheta = std::cos(theta);
+			float const sinTheta = std::sin(theta);
+
+			glm::vec3 vertex;
+			vertex.x = radius * sinTheta;
+			vertex.y = halfHeight * sign;
+			vertex.z = radius * cosTheta;
+			vertices.push_back(vertex);
+
+			normals.push_back(glm::vec3(0.0f, sign, 0.0f));
+			++index;
+		}
+
+		for (int x = 0; x < radialSegments; ++x)
+		{
+			int const c = centerIndexStart + x;
+			int const i = centerIndexEnd + x;
+			if (top)
+			{
+				indices.push_back(static_cast<unsigned int>(i));
+				indices.push_back(static_cast<unsigned int>(i + 1));
+				indices.push_back(static_cast<unsigned int>(c));
+			}
+			else
+			{
+				indices.push_back(static_cast<unsigned int>(i + 1));
+				indices.push_back(static_cast<unsigned int>(i));
+				indices.push_back(static_cast<unsigned int>(c));
+			}
+		}
+	};
+
+	generateTorso();
+	if (radiusTop > 0.0f)
+		generateCap(true);
+	if (radiusBottom > 0.0f)
+		generateCap(false);
+}

--- a/src/primitives/cylinder.h
+++ b/src/primitives/cylinder.h
@@ -1,0 +1,49 @@
+#ifndef CYLINDER_H
+#define CYLINDER_H
+
+#include "../core/mesh.h"
+
+/** Full height along Y; bottom at y = -height/2, top at y = +height/2. Equal radii = right cylinder. */
+class CylinderDimensions
+{
+public:
+	CylinderDimensions(GLfloat radiusBottom, GLfloat radiusTop, GLfloat height)
+			: radiusBottom{radiusBottom}, radiusTop{radiusTop}, height{height}
+	{
+	}
+	GLfloat radiusBottom;
+	GLfloat radiusTop;
+	GLfloat height;
+};
+
+class CylinderParameters
+{
+public:
+	CylinderParameters(int radialSegments = 16, int heightSegments = 1)
+			: radialSegments{radialSegments}, heightSegments{heightSegments}
+	{
+	}
+	int radialSegments;
+	int heightSegments;
+};
+
+class Cylinder : public Mesh
+{
+public:
+	Cylinder(CylinderDimensions const &dimensions = CylinderDimensions{0.5f, 0.5f, 1.0f},
+			CylinderParameters const &parameters = CylinderParameters{});
+	~Cylinder();
+
+	CylinderDimensions getDimensions() const { return dimensions; }
+	void setDimensions(CylinderDimensions const &d) { dimensions = d; }
+	CylinderParameters getParameters() const { return parameters; }
+	void setParameters(CylinderParameters const &p) { parameters = p; }
+	void rebuildGeometry();
+
+private:
+	void createVertices();
+	CylinderDimensions dimensions;
+	CylinderParameters parameters;
+};
+
+#endif

--- a/src/primitives/pyramid.cpp
+++ b/src/primitives/pyramid.cpp
@@ -11,12 +11,27 @@ Pyramid::Pyramid(PyramidDimensions dimensions) : Mesh{}, dimensions{dimensions}
 
 Pyramid::Pyramid(Pyramid const &pyramid) : Mesh{}, dimensions{pyramid.dimensions}
 {
-    createVertices();
-    createMesh();
+	createVertices();
+	computeFaces();
+	createMesh();
 }
 
 Pyramid::~Pyramid()
 {
+}
+
+void Pyramid::rebuildGeometry()
+{
+	ClearMesh();
+	vertices.clear();
+	normals.clear();
+	faces.clear();
+	indices.clear();
+	createVertices();
+	computeFaces();
+	createMesh();
+	threeBSPDone = false;
+	computeThreeBSP();
 }
 
 void Pyramid::createVertices()

--- a/src/primitives/pyramid.h
+++ b/src/primitives/pyramid.h
@@ -19,6 +19,7 @@ public:
 
   inline PyramidDimensions getDimensions() const { return dimensions; };
   inline void setDimensions(PyramidDimensions const &dimensions) { this->dimensions = dimensions; };
+  void rebuildGeometry();
 
 private:
   void createVertices();

--- a/src/primitives/sphere.cpp
+++ b/src/primitives/sphere.cpp
@@ -1,12 +1,15 @@
 #include "sphere.h"
 #include <cmath>
 #include <iostream>
+#include <vector>
+
+/** Three.js `SphereGeometry` (r162) — same vertex, normal, and index order. */
 
 Sphere::Sphere(SphereDimensions const &dimensions, SphereParameters const &parameters) : Mesh{}, dimensions{dimensions}, parameters{parameters}
 {
-  createVertices();
-  computeFaces();
-  createMesh();
+	createVertices();
+	computeFaces();
+	createMesh();
 }
 
 Sphere::~Sphere()
@@ -29,81 +32,74 @@ void Sphere::rebuildGeometry()
 
 void Sphere::createVertices()
 {
-  auto radius = dimensions.radius;
-  auto heightSegments = parameters.heightSegments;
-  auto widthSegments = parameters.widthSegments;
-  auto phiStart = parameters.phiStart;
-  auto phiLength = parameters.phiLength;
-  auto thetaStart = parameters.thetaStart;
-  auto thetaLength = parameters.thetaLength;
+	widthSegments = std::max(3, parameters.widthSegments);
+	heightSegments = std::max(2, parameters.heightSegments);
 
-  int index = 0;
-  std::vector<std::vector<int>> grid;
+	float const radius = std::max(1e-4f, dimensions.radius);
+	float const phiStart = parameters.phiStart;
+	float const phiLength = parameters.phiLength;
+	float const thetaStart = parameters.thetaStart;
+	float const thetaLength = parameters.thetaLength;
 
-  widthSegments = std::max(3, widthSegments);
-  heightSegments = std::max(2, heightSegments);
+	float const thetaEnd = std::min(thetaStart + thetaLength, static_cast<float>(M_PI));
 
-  auto thetaEnd = std::min(thetaStart + thetaLength, float(M_PI));
+	vertices.clear();
+	normals.clear();
+	indices.clear();
 
-  for (size_t iy{0}; iy <= heightSegments; iy++)
-  {
-    std::vector<int> verticesRow;
-    auto v = iy / (float)heightSegments;
-    auto uOffset = 0;
-    if (iy == 0 && thetaStart == 0)
-    {
-      uOffset = 0.5 / widthSegments;
-    }
-    else if (iy == heightSegments && thetaEnd >= M_PI)
-    {
-      uOffset = -0.5 / widthSegments;
-    }
+	std::vector<std::vector<int>> grid;
+	int index = 0;
 
-    for (size_t ix{0}; ix <= widthSegments; ix++)
-    {
-      auto u = ix / (float)widthSegments;
-      auto vertex = glm::vec3();
-      vertex.x = -radius * cos(phiStart + u * phiLength) * sin(thetaStart + v * thetaLength);
-      vertex.y = radius * cos(thetaStart + v * thetaLength);
-      vertex.z = radius * sin(phiStart + u * phiLength) * sin(thetaStart + v * thetaLength);
-      this->vertices.push_back(vertex);
+	for (size_t iy = 0; iy <= static_cast<size_t>(heightSegments); ++iy)
+	{
+		std::vector<int> verticesRow;
+		float const v = static_cast<float>(iy) / static_cast<float>(heightSegments);
 
-      // normal
-      auto normal = glm::normalize(glm::vec3(vertex));
-      this->normals.push_back(normal);
+		float uOffset = 0.0f;
+		if (iy == 0 && thetaStart == 0.0f)
+			uOffset = 0.5f / static_cast<float>(widthSegments);
+		else if (static_cast<int>(iy) == heightSegments && thetaEnd >= static_cast<float>(M_PI))
+			uOffset = -0.5f / static_cast<float>(widthSegments);
 
-      // uv
-      // auto uv = glm::vec2(u + uOffset, 1.0f - v);
-      // this->uvs.push_back(uv);
+		for (size_t ix = 0; ix <= static_cast<size_t>(widthSegments); ++ix)
+		{
+			float const u = static_cast<float>(ix) / static_cast<float>(widthSegments);
 
-      verticesRow.push_back(index++);
-    }
-    grid.push_back(verticesRow);
-  }
+			glm::vec3 vertex;
+			vertex.x = -radius * std::cos(phiStart + u * phiLength) * std::sin(thetaStart + v * thetaLength);
+			vertex.y = radius * std::cos(thetaStart + v * thetaLength);
+			vertex.z = radius * std::sin(phiStart + u * phiLength) * std::sin(thetaStart + v * thetaLength);
+			vertices.push_back(vertex);
 
-  // indices
+			glm::vec3 const normal = glm::normalize(vertex);
+			normals.push_back(normal);
 
-  for (size_t iy{0}; iy < heightSegments; iy++)
-  {
-    for (size_t ix{0}; ix < widthSegments; ix++)
-    {
-      auto a = grid.at(iy).at(ix + 1);
-      auto b = grid.at(iy).at(ix);
-      auto c = grid.at(iy + 1).at(ix);
-      auto d = grid.at(iy + 1).at(ix + 1);
+			verticesRow.push_back(index++);
+		}
+		grid.push_back(std::move(verticesRow));
+	}
 
-      if (iy != 0 || thetaStart > 0)
-      {
-        this->indices.push_back(a);
-        this->indices.push_back(b);
-        this->indices.push_back(d);
-      }
-      if (iy != heightSegments - 1 || thetaEnd < M_PI)
-      {
-        this->indices.push_back(b);
-        this->indices.push_back(c);
-        this->indices.push_back(d);
-      }
-    }
-  }
+	for (size_t iy = 0; iy < static_cast<size_t>(heightSegments); ++iy)
+	{
+		for (size_t ix = 0; ix < static_cast<size_t>(widthSegments); ++ix)
+		{
+			int const a = grid[iy][ix + 1];
+			int const b = grid[iy][ix];
+			int const c = grid[iy + 1][ix];
+			int const d = grid[iy + 1][ix + 1];
+
+			if (iy != 0 || thetaStart > 0.0f)
+			{
+				indices.push_back(static_cast<unsigned int>(a));
+				indices.push_back(static_cast<unsigned int>(b));
+				indices.push_back(static_cast<unsigned int>(d));
+			}
+			if (static_cast<int>(iy) != heightSegments - 1 || thetaEnd < static_cast<float>(M_PI))
+			{
+				indices.push_back(static_cast<unsigned int>(b));
+				indices.push_back(static_cast<unsigned int>(c));
+				indices.push_back(static_cast<unsigned int>(d));
+			}
+		}
+	}
 }

--- a/src/primitives/torus.cpp
+++ b/src/primitives/torus.cpp
@@ -1,0 +1,88 @@
+#include "torus.h"
+#include <algorithm>
+#include <cmath>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+/** Three.js `TorusGeometry` (r162): radius, tube, radialSegments, tubularSegments, arc=2π */
+
+Torus::Torus(TorusDimensions const &dimensions, TorusParameters const &parameters)
+		: Mesh{}, dimensions{dimensions}, parameters{parameters}
+{
+	createVertices();
+	computeFaces();
+	createMesh();
+}
+
+Torus::~Torus() = default;
+
+void Torus::rebuildGeometry()
+{
+	ClearMesh();
+	vertices.clear();
+	normals.clear();
+	faces.clear();
+	indices.clear();
+	createVertices();
+	computeFaces();
+	createMesh();
+	threeBSPDone = false;
+	computeThreeBSP();
+}
+
+void Torus::createVertices()
+{
+	int const radialSegments = std::max(3, parameters.radialSegments);
+	int const tubularSegments = std::max(3, parameters.tubularSegments);
+	float const radius = std::max(1e-4f, dimensions.majorRadius);
+	float const tube = std::max(1e-4f, dimensions.minorRadius);
+	float const arc = static_cast<float>(2.0 * M_PI);
+
+	vertices.clear();
+	normals.clear();
+	indices.clear();
+
+	glm::vec3 center(0.0f);
+
+	for (int j = 0; j <= radialSegments; ++j)
+	{
+		for (int i = 0; i <= tubularSegments; ++i)
+		{
+			float const u = static_cast<float>(i) / static_cast<float>(tubularSegments) * arc;
+			float const v = static_cast<float>(j) / static_cast<float>(radialSegments) * static_cast<float>(2.0 * M_PI);
+
+			glm::vec3 vertex;
+			vertex.x = (radius + tube * std::cos(v)) * std::cos(u);
+			vertex.y = (radius + tube * std::cos(v)) * std::sin(u);
+			vertex.z = tube * std::sin(v);
+			vertices.push_back(vertex);
+
+			center.x = radius * std::cos(u);
+			center.y = radius * std::sin(u);
+			center.z = 0.0f;
+			glm::vec3 normal = vertex - center;
+			float const nl = glm::length(normal);
+			normal = nl > 1e-20f ? normal / nl : glm::vec3(0.0f, 0.0f, 1.0f);
+			normals.push_back(normal);
+		}
+	}
+
+	for (int j = 1; j <= radialSegments; ++j)
+	{
+		for (int i = 1; i <= tubularSegments; ++i)
+		{
+			int const a = (tubularSegments + 1) * j + i - 1;
+			int const b = (tubularSegments + 1) * (j - 1) + i - 1;
+			int const c = (tubularSegments + 1) * (j - 1) + i;
+			int const d = (tubularSegments + 1) * j + i;
+			indices.push_back(static_cast<unsigned int>(a));
+			indices.push_back(static_cast<unsigned int>(b));
+			indices.push_back(static_cast<unsigned int>(d));
+			indices.push_back(static_cast<unsigned int>(b));
+			indices.push_back(static_cast<unsigned int>(c));
+			indices.push_back(static_cast<unsigned int>(d));
+		}
+	}
+}

--- a/src/primitives/torus.h
+++ b/src/primitives/torus.h
@@ -1,0 +1,48 @@
+#ifndef TORUS_H
+#define TORUS_H
+
+#include "../core/mesh.h"
+
+/** Standard torus around +Z: major = ring radius (hole to tube center), minor = tube radius. */
+class TorusDimensions
+{
+public:
+	TorusDimensions(GLfloat majorRadius = 0.6f, GLfloat minorRadius = 0.2f)
+			: majorRadius{majorRadius}, minorRadius{minorRadius}
+	{
+	}
+	GLfloat majorRadius;
+	GLfloat minorRadius;
+};
+
+class TorusParameters
+{
+public:
+	TorusParameters(int radialSegments = 16, int tubularSegments = 32)
+			: radialSegments{radialSegments}, tubularSegments{tubularSegments}
+	{
+	}
+	int radialSegments;
+	int tubularSegments;
+};
+
+class Torus : public Mesh
+{
+public:
+	Torus(TorusDimensions const &dimensions = TorusDimensions{},
+			TorusParameters const &parameters = TorusParameters{});
+	~Torus();
+
+	TorusDimensions getDimensions() const { return dimensions; }
+	void setDimensions(TorusDimensions const &d) { dimensions = d; }
+	TorusParameters getParameters() const { return parameters; }
+	void setParameters(TorusParameters const &p) { parameters = p; }
+	void rebuildGeometry();
+
+private:
+	void createVertices();
+	TorusDimensions dimensions;
+	TorusParameters parameters;
+};
+
+#endif

--- a/src/threecsg/polygon.cpp
+++ b/src/threecsg/polygon.cpp
@@ -145,7 +145,11 @@ void Polygon::splitPolygon(shared_ptr<Polygon> const &polygon, vector<shared_ptr
       {
         glm::vec3 const edge = vj->position - vi->position;
         float const denom = glm::dot(planeN, edge);
-        float const t = (this->w - glm::dot(planeN, vi->position)) / denom;
+        /** Edge parallel to cutting plane: skip bogus intersection (avoids holes / spikes). */
+        if (std::abs(denom) < 1e-8f)
+          continue;
+        float t = (this->w - glm::dot(planeN, vi->position)) / denom;
+        t = glm::clamp(t, 0.0f, 1.0f);
         auto v = vi->interpolate(vj, t);
         front_vertices.push_back(v);
         back_vertices.push_back(v);

--- a/src/threecsg/threebsp.cpp
+++ b/src/threecsg/threebsp.cpp
@@ -1,11 +1,156 @@
 #include "threebsp.h"
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <numeric>
 #include <vector>
 #include "glm/glm.hpp"
-#include <map>
+#include <glm/gtc/matrix_inverse.hpp>
 #include "../complexobjects/csgmesh.h"
-#include <set>
+#include <utility>
 
 using namespace std;
+
+namespace
+{
+
+float cross2(glm::vec2 const &a, glm::vec2 const &b, glm::vec2 const &c)
+{
+	return (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x);
+}
+
+float signedArea2(vector<glm::vec2> const &p)
+{
+	float a = 0.f;
+	for (size_t i = 0; i < p.size(); ++i)
+	{
+		size_t const j = (i + 1) % p.size();
+		a += p[i].x * p[j].y - p[j].x * p[i].y;
+	}
+	return a * 0.5f;
+}
+
+/** Strict interior (CCW triangle abc); avoids rejecting valid ears when verts lie on edges. */
+bool pointInsideTriStrict(glm::vec2 const &p, glm::vec2 const &a, glm::vec2 const &b, glm::vec2 const &c)
+{
+	float const e = 1e-6f;
+	float const s1 = cross2(a, b, p);
+	float const s2 = cross2(b, c, p);
+	float const s3 = cross2(c, a, p);
+	return (s1 > e) && (s2 > e) && (s3 > e);
+}
+
+vector<glm::vec3> collapseConsecutive(vector<glm::vec3> const &in, float const eps2)
+{
+	vector<glm::vec3> out;
+	for (auto const &p : in)
+	{
+		if (out.empty() || glm::dot(p - out.back(), p - out.back()) > eps2)
+			out.push_back(p);
+	}
+	if (out.size() >= 3 && glm::dot(out.front() - out.back(), out.front() - out.back()) <= eps2)
+		out.pop_back();
+	return out;
+}
+
+vector<array<int, 3>> earClip2d(vector<glm::vec2> const &p2)
+{
+	int const n0 = static_cast<int>(p2.size());
+	vector<int> V(n0);
+	iota(V.begin(), V.end(), 0);
+	vector<array<int, 3>> tris;
+	int guard = 0;
+	while (static_cast<int>(V.size()) > 3 && guard++ < 1000000)
+	{
+		bool found = false;
+		int const nv = static_cast<int>(V.size());
+		for (int i = 0; i < nv; ++i)
+		{
+			int const i0 = V[(i + nv - 1) % nv];
+			int const i1 = V[i];
+			int const i2 = V[(i + 1) % nv];
+			glm::vec2 const &a = p2[i0];
+			glm::vec2 const &b = p2[i1];
+			glm::vec2 const &c = p2[i2];
+			if (cross2(a, b, c) <= 1e-12f)
+				continue;
+			bool empty = true;
+			for (int k : V)
+			{
+				if (k == i0 || k == i1 || k == i2)
+					continue;
+				if (pointInsideTriStrict(p2[k], a, b, c))
+				{
+					empty = false;
+					break;
+				}
+			}
+			if (!empty)
+				continue;
+			tris.push_back({i0, i1, i2});
+			V.erase(V.begin() + i);
+			found = true;
+			break;
+		}
+		if (!found)
+			break;
+	}
+	if (V.size() == 3)
+		tris.push_back({V[0], V[1], V[2]});
+	return tris;
+}
+
+/** Simple polygons only (BSP output); handles concave clips — unlike triangle fans. */
+vector<array<glm::vec3, 3>> triangulatePlanarNgon(vector<glm::vec3> pts, glm::vec3 const &nMesh)
+{
+	vector<array<glm::vec3, 3>> out;
+	pts = collapseConsecutive(pts, 1e-14f);
+	if (pts.size() < 3)
+		return out;
+	if (pts.size() == 3)
+	{
+		out.push_back({pts[0], pts[1], pts[2]});
+		return out;
+	}
+
+	glm::vec3 const n = glm::length(nMesh) > 1e-20f ? glm::normalize(nMesh) : glm::vec3(0.f, 1.f, 0.f);
+	glm::vec3 u = glm::cross(n, glm::abs(n.x) < 0.9f ? glm::vec3(1.f, 0.f, 0.f) : glm::vec3(0.f, 1.f, 0.f));
+	if (glm::dot(u, u) < 1e-20f)
+		u = glm::cross(n, glm::vec3(0.f, 0.f, 1.f));
+	u = glm::normalize(u);
+	glm::vec3 const v = glm::normalize(glm::cross(u, n));
+
+	vector<glm::vec2> p2(pts.size());
+	auto rebuildP2 = [&]()
+	{
+		glm::vec3 const o = pts[0];
+		for (size_t i = 0; i < pts.size(); ++i)
+		{
+			glm::vec3 const d = pts[i] - o;
+			p2[i] = glm::vec2(glm::dot(d, u), glm::dot(d, v));
+		}
+	};
+	rebuildP2();
+	if (signedArea2(p2) < 0.f)
+	{
+		reverse(pts.begin(), pts.end());
+		rebuildP2();
+	}
+
+	vector<array<int, 3>> tris = earClip2d(p2);
+	size_t const expected = pts.size() >= 3 ? pts.size() - 2 : 0;
+	if (tris.size() != expected && pts.size() >= 3)
+	{
+		tris.clear();
+		for (size_t j = 2; j < pts.size(); ++j)
+			tris.push_back({0, static_cast<int>(j - 1), static_cast<int>(j)});
+	}
+	for (auto const &t : tris)
+		out.push_back({pts[static_cast<size_t>(t[0])], pts[static_cast<size_t>(t[1])], pts[static_cast<size_t>(t[2])]});
+	return out;
+}
+
+} // namespace
 
 ThreeBSP::ThreeBSP(shared_ptr<Node> const &node)
 {
@@ -22,8 +167,9 @@ ThreeBSP::ThreeBSP(shared_ptr<Mesh> const &mesh)
   _node = make_shared<Node>();
   _vertex = make_shared<Vertex>();
 
-  // matrix = make_shared<glm::mat4x4>(glm::mat4x4(*mesh->getModelMatrix()));
-  matrix = mesh->getModelMatrix();
+  /** Own a copy so BSP geometry and `toMesh()` inverse stay aligned with the transform used here,
+   *  even if `mesh->model` is mutated before the next `computeThreeBSP()`. */
+  matrix = make_shared<glm::mat4>(*mesh->getModelMatrix());
   auto geometry = mesh;
   vector<shared_ptr<Polygon>> polygons;
   polygons.reserve(geometry->faces.size());
@@ -113,9 +259,12 @@ shared_ptr<ThreeBSP> ThreeBSP::intersect(shared_ptr<ThreeBSP> const &other_tree)
 
 shared_ptr<CSGMesh> ThreeBSP::toMesh()
 {
-  set<pair<string, int>> vertice_dict;
-  auto matrix = make_shared<glm::mat4x4>(glm::mat4x4(*(this->matrix)));
-  *matrix = glm::inverse(*matrix);
+  /** BSP polygons live in world space (built from meshes with model applied). Bake into
+   *  the first operand's model space using inverse(model), but the rendered mesh must use
+   *  the original model matrix — setting model to inverse(model) was double-applying the
+   *  inverse and broke unions whenever operands were moved or rotated. */
+  auto const invModelPtr = make_shared<glm::mat4x4>(glm::mat4x4(glm::inverse(*this->matrix)));
+  glm::mat3 const normalToMesh = glm::mat3(glm::inverse(*this->matrix));
   auto mesh = make_shared<CSGMesh>();
   auto polygons = this->tree->allPolygons();
   size_t faceTotal = 0;
@@ -130,66 +279,40 @@ shared_ptr<CSGMesh> ThreeBSP::toMesh()
   for (size_t i{0}; i < polygons.size(); i++)
   {
     auto polygon = polygons.at(i);
-    for (size_t j{2}; j < polygon->vertices.size(); j++)
+    glm::vec3 const nWorld(polygon->normal->position.x, polygon->normal->position.y, polygon->normal->position.z);
+    glm::vec3 const nMesh = glm::normalize(normalToMesh * nWorld);
+
+    vector<glm::vec3> meshRing;
+    meshRing.reserve(polygon->vertices.size());
+    for (auto const &vv : polygon->vertices)
     {
-      // std::vector<shared_ptr<glm::vec2>> verticeUvs;
-      auto vertex = polygon->vertices.at(0);
-      // verticeUvs.push_back(make_shared<glm::vec2>(glm::vec2(vertex->uv.x, vertex->uv.y)));
-      auto vertex3 = make_shared<glm::vec3>(glm::vec3(vertex->position.x, vertex->position.y, vertex->position.z));
-      vertex3 = applyMatrix4(vertex3, matrix);
-      int vertex_idx_a;
-      if (exists(vertice_dict, make_key(vertex3)))
-      {
-        vertex_idx_a = getValue(vertice_dict, make_key(vertex3));
-      }
-      else
-      {
-        mesh->vertices.push_back(*vertex3);
-        addPair(vertice_dict, make_key(vertex3), mesh->vertices.size() - 1);
-        vertex_idx_a = mesh->vertices.size() - 1;
-      }
+      auto const w = make_shared<glm::vec3>(vv->position);
+      meshRing.push_back(*applyMatrix4(w, invModelPtr));
+    }
 
-      vertex = polygon->vertices.at(j - 1);
-      // verticeUvs.push_back(make_shared<glm::vec2>(glm::vec2(vertex->uv.x, vertex->uv.y)));
-      vertex3 = make_shared<glm::vec3>(glm::vec3(vertex->position.x, vertex->position.y, vertex->position.z));
-      vertex3 = applyMatrix4(vertex3, matrix);
-      int vertex_idx_b;
-      if (exists(vertice_dict, make_key(vertex3)))
-      {
-        vertex_idx_b = getValue(vertice_dict, make_key(vertex3));
-      }
-      else
-      {
-        mesh->vertices.push_back(*vertex3);
-        addPair(vertice_dict, make_key(vertex3), mesh->vertices.size() - 1);
-        vertex_idx_b = mesh->vertices.size() - 1;
-      }
+    vector<array<glm::vec3, 3>> const tris = triangulatePlanarNgon(meshRing, nMesh);
+    for (auto const &tri : tris)
+    {
+      glm::vec3 pa = tri[0];
+      glm::vec3 pb = tri[1];
+      glm::vec3 pc = tri[2];
 
-      vertex = polygon->vertices.at(j);
-      // verticeUvs.push_back(make_shared<glm::vec2>(glm::vec2(vertex->uv.x, vertex->uv.y)));
-      vertex3 = make_shared<glm::vec3>(glm::vec3(vertex->position.x, vertex->position.y, vertex->position.z));
-      vertex3 = applyMatrix4(vertex3, matrix);
-      int vertex_idx_c;
-      if (exists(vertice_dict, make_key(vertex3)))
-      {
-        vertex_idx_c = getValue(vertice_dict, make_key(vertex3));
-      }
-      else
-      {
-        mesh->vertices.push_back(*vertex3);
-        addPair(vertice_dict, make_key(vertex3), mesh->vertices.size() - 1);
-        vertex_idx_c = mesh->vertices.size() - 1;
-      }
+      glm::vec3 const geomN = glm::cross(pb - pa, pc - pa);
+      if (glm::dot(geomN, geomN) > 1e-24f && glm::dot(geomN, nMesh) < 0.0f)
+        std::swap(pb, pc);
 
-      auto face = make_shared<Face3>(Face3(vertex_idx_a,
-                                           vertex_idx_b,
-                                           vertex_idx_c,
-                                           glm::vec3(
-                                               polygon->normal->position.x,
-                                               polygon->normal->position.y,
-                                               polygon->normal->position.z)));
+      unsigned int const vertex_idx_a = static_cast<unsigned int>(mesh->vertices.size());
+      mesh->vertices.push_back(pa);
+      unsigned int const vertex_idx_b = static_cast<unsigned int>(mesh->vertices.size());
+      mesh->vertices.push_back(pb);
+      unsigned int const vertex_idx_c = static_cast<unsigned int>(mesh->vertices.size());
+      mesh->vertices.push_back(pc);
+
+      auto face = make_shared<Face3>(Face3(static_cast<int>(vertex_idx_a),
+                                           static_cast<int>(vertex_idx_b),
+                                           static_cast<int>(vertex_idx_c),
+                                           nMesh));
       mesh->faces.push_back(face);
-      // mesh->faceVertexUvs.at(0).push_back(verticeUvs);
     }
   }
   // faces to indices
@@ -199,7 +322,7 @@ shared_ptr<CSGMesh> ThreeBSP::toMesh()
     mesh->indices.push_back(face->b);
     mesh->indices.push_back(face->c);
   }
-  mesh->setModel(matrix);
+  mesh->setModel(make_shared<glm::mat4>(*this->matrix));
   mesh->createMesh();
   mesh->computeThreeBSP();
 
@@ -214,58 +337,4 @@ shared_ptr<glm::vec3> applyMatrix4(shared_ptr<glm::vec3> const &v, shared_ptr<gl
   auto y = (elements[1] * v->x + elements[5] * v->y + elements[9] * v->z + elements[13]) * w;
   auto z = (elements[2] * v->x + elements[6] * v->y + elements[10] * v->z + elements[14]) * w;
   return make_shared<glm::vec3>(glm::vec3(x, y, z));
-}
-
-bool operator==(pair<string, int> const &a, pair<string, int> const &b)
-{
-  return a.first == b.first;
-}
-
-bool operator<(pair<string, int> const &a, pair<string, int> const &b)
-{
-  return a.first < b.first;
-}
-
-bool operator>(pair<string, int> const &a, pair<string, int> const &b)
-{
-  return a.first > b.first;
-}
-
-bool operator<=(pair<string, int> const &a, pair<string, int> const &b)
-{
-  return a.first <= b.first;
-}
-
-bool operator>=(pair<string, int> const &a, pair<string, int> const &b)
-{
-  return a.first >= b.first;
-}
-
-bool operator!=(pair<string, int> const &a, pair<string, int> const &b)
-{
-  return a.first != b.first;
-}
-
-bool exists(set<pair<string, int>> const &data, string key)
-{
-  if (data.find(make_pair(key, 0)) != data.end())
-  {
-    return true;
-  }
-  return false;
-}
-
-int getValue(set<pair<string, int>> const &data, string key)
-{
-  return data.find(make_pair(key, 0))->second;
-}
-string make_key(shared_ptr<glm::vec3> const &v)
-{
-  return to_string(v->x) + "," + to_string(v->y) + "," + to_string(v->z);
-}
-
-set<pair<string, int>> &addPair(set<pair<string, int>> &data, string key, int value)
-{
-  data.insert(make_pair(key, value));
-  return data;
 }

--- a/src/threecsg/threebsp.h
+++ b/src/threecsg/threebsp.h
@@ -2,7 +2,6 @@
 #define THREE_BSP_H
 
 #include <memory>
-#include <set>
 #include "polygon.h"
 #include "vertex.h"
 #include "node.h"
@@ -33,16 +32,5 @@ private:
 };
 
 shared_ptr<glm::vec3> applyMatrix4(shared_ptr<glm::vec3> const &v, shared_ptr<glm::mat4x4> const &m);
-bool exists(set<pair<string, int>> const &data, string key);
-int getValue(set<pair<string, int>> const &data, string key);
-string make_key(shared_ptr<glm::vec3> const &v);
-set<pair<string, int>> &addPair(set<pair<string, int>> &data, string key, int value);
-
-bool operator==(pair<string, int> const &a, pair<string, int> const &b);
-bool operator<(pair<string, int> const &a, pair<string, int> const &b);
-bool operator>(pair<string, int> const &a, pair<string, int> const &b);
-bool operator!=(pair<string, int> const &a, pair<string, int> const &b);
-bool operator<=(pair<string, int> const &a, pair<string, int> const &b);
-bool operator>=(pair<string, int> const &a, pair<string, int> const &b);
 
 #endif

--- a/src/threecsg/types.h
+++ b/src/threecsg/types.h
@@ -1,7 +1,8 @@
 #ifndef TYPES_H
 #define TYPES_H
 
-#define EPSILON 1e-5
+/** Plane tests / clipping; slightly relaxed vs 1e-5 for float CSG after transforms. */
+#define EPSILON 2e-4f
 
 enum CLASSIFICATION
 {

--- a/wasmbuild/mypage.html
+++ b/wasmbuild/mypage.html
@@ -254,6 +254,9 @@
         <select id="addType" aria-label="Object type to add">
           <option value="cube">Box (width, height, depth)</option>
           <option value="sphere">Sphere (radius, mesh detail)</option>
+          <option value="pyramid">Pyramid (base edge, height)</option>
+          <option value="cylinder">Cylinder / frustum (radii, height, segments)</option>
+          <option value="torus">Torus (major / minor radius, segments)</option>
         </select>
         <div id="addCubeFields">
           <div class="grid-2">
@@ -287,6 +290,64 @@
             </div>
           </div>
         </div>
+        <div id="addPyramidFields" class="hidden">
+          <div class="grid-2">
+            <div>
+              <label class="field-label" for="addPyrSide">Base edge</label>
+              <input type="number" id="addPyrSide" min="0.01" step="0.05" value="1" />
+            </div>
+            <div>
+              <label class="field-label" for="addPyrH">Height</label>
+              <input type="number" id="addPyrH" min="0.01" step="0.05" value="1" />
+            </div>
+          </div>
+        </div>
+        <div id="addCylinderFields" class="hidden">
+          <p class="section-desc" style="margin-bottom: 8px">Same top &amp; bottom radius = cylinder; different = truncated cone.</p>
+          <div class="grid-2">
+            <div>
+              <label class="field-label" for="addCylRb">Radius bottom</label>
+              <input type="number" id="addCylRb" min="0.01" step="0.05" value="0.35" />
+            </div>
+            <div>
+              <label class="field-label" for="addCylRt">Radius top</label>
+              <input type="number" id="addCylRt" min="0.01" step="0.05" value="0.35" />
+            </div>
+            <div>
+              <label class="field-label" for="addCylH">Height</label>
+              <input type="number" id="addCylH" min="0.01" step="0.05" value="1" />
+            </div>
+            <div>
+              <label class="field-label" for="addCylRs">Radial segments</label>
+              <input type="number" id="addCylRs" min="3" step="1" value="24" />
+            </div>
+            <div>
+              <label class="field-label" for="addCylHs">Height segments</label>
+              <input type="number" id="addCylHs" min="1" step="1" value="1" />
+            </div>
+          </div>
+        </div>
+        <div id="addTorusFields" class="hidden">
+          <p class="section-desc" style="margin-bottom: 8px">Major = ring radius; minor = tube radius (must be &lt; major).</p>
+          <div class="grid-2">
+            <div>
+              <label class="field-label" for="addTorMaj">Major radius</label>
+              <input type="number" id="addTorMaj" min="0.01" step="0.05" value="0.55" />
+            </div>
+            <div>
+              <label class="field-label" for="addTorMin">Minor radius</label>
+              <input type="number" id="addTorMin" min="0.01" step="0.05" value="0.18" />
+            </div>
+            <div>
+              <label class="field-label" for="addTorRs">Tube segments</label>
+              <input type="number" id="addTorRs" min="3" step="1" value="16" />
+            </div>
+            <div>
+              <label class="field-label" for="addTorTs">Ring segments</label>
+              <input type="number" id="addTorTs" min="3" step="1" value="32" />
+            </div>
+          </div>
+        </div>
         <div class="btn-row" style="margin-top: 10px">
           <button type="button" id="btnAddObject" class="primary">Add to scene</button>
         </div>
@@ -306,7 +367,7 @@
 
       <div class="card">
         <h2>3 · Resize selection</h2>
-        <p class="section-desc">Boxes use full width / height / depth. Spheres use radius and segment counts (mesh quality).</p>
+        <p class="section-desc">Dimensions match each primitive (box, sphere, pyramid, cylinder/frustum, torus). CSG results cannot be resized here.</p>
         <p id="resizeUnavailable" class="section-desc hidden">CSG results cannot be resized here — add a new primitive instead.</p>
         <div id="resizeBoxFields">
           <div class="grid-2">
@@ -344,6 +405,71 @@
           </div>
           <div class="btn-row" style="margin-top: 10px">
             <button type="button" id="btnApplySphereResize" class="primary">Apply sphere size</button>
+          </div>
+        </div>
+        <div id="resizePyramidFields" class="hidden">
+          <div class="grid-2">
+            <div>
+              <label class="field-label" for="resPyrSide">Base edge</label>
+              <input type="number" id="resPyrSide" min="0.01" step="0.05" value="1" />
+            </div>
+            <div>
+              <label class="field-label" for="resPyrH">Height</label>
+              <input type="number" id="resPyrH" min="0.01" step="0.05" value="1" />
+            </div>
+          </div>
+          <div class="btn-row" style="margin-top: 10px">
+            <button type="button" id="btnApplyPyramidResize" class="primary">Apply pyramid size</button>
+          </div>
+        </div>
+        <div id="resizeCylinderFields" class="hidden">
+          <div class="grid-2">
+            <div>
+              <label class="field-label" for="resCylRb">Radius bottom</label>
+              <input type="number" id="resCylRb" min="0.01" step="0.05" value="0.35" />
+            </div>
+            <div>
+              <label class="field-label" for="resCylRt">Radius top</label>
+              <input type="number" id="resCylRt" min="0.01" step="0.05" value="0.35" />
+            </div>
+            <div>
+              <label class="field-label" for="resCylH">Height</label>
+              <input type="number" id="resCylH" min="0.01" step="0.05" value="1" />
+            </div>
+            <div>
+              <label class="field-label" for="resCylRs">Radial segments</label>
+              <input type="number" id="resCylRs" min="3" step="1" value="24" />
+            </div>
+            <div>
+              <label class="field-label" for="resCylHs">Height segments</label>
+              <input type="number" id="resCylHs" min="1" step="1" value="1" />
+            </div>
+          </div>
+          <div class="btn-row" style="margin-top: 10px">
+            <button type="button" id="btnApplyCylinderResize" class="primary">Apply cylinder size</button>
+          </div>
+        </div>
+        <div id="resizeTorusFields" class="hidden">
+          <div class="grid-2">
+            <div>
+              <label class="field-label" for="resTorMaj">Major radius</label>
+              <input type="number" id="resTorMaj" min="0.01" step="0.05" value="0.55" />
+            </div>
+            <div>
+              <label class="field-label" for="resTorMin">Minor radius</label>
+              <input type="number" id="resTorMin" min="0.01" step="0.05" value="0.18" />
+            </div>
+            <div>
+              <label class="field-label" for="resTorRs">Tube segments</label>
+              <input type="number" id="resTorRs" min="3" step="1" value="16" />
+            </div>
+            <div>
+              <label class="field-label" for="resTorTs">Ring segments</label>
+              <input type="number" id="resTorTs" min="3" step="1" value="32" />
+            </div>
+          </div>
+          <div class="btn-row" style="margin-top: 10px">
+            <button type="button" id="btnApplyTorusResize" class="primary">Apply torus size</button>
           </div>
         </div>
       </div>
@@ -444,14 +570,26 @@
     document.getElementById("panStepLabel").textContent = String(PAN_STEP);
 
     var addType = document.getElementById("addType");
-    var addCubeFields = document.getElementById("addCubeFields");
-    var addSphereFields = document.getElementById("addSphereFields");
-
-    addType.addEventListener("change", function () {
-      var sp = addType.value === "sphere";
-      addCubeFields.classList.toggle("hidden", sp);
-      addSphereFields.classList.toggle("hidden", !sp);
-    });
+    var addFieldGroups = {
+      cube: document.getElementById("addCubeFields"),
+      sphere: document.getElementById("addSphereFields"),
+      pyramid: document.getElementById("addPyramidFields"),
+      cylinder: document.getElementById("addCylinderFields"),
+      torus: document.getElementById("addTorusFields"),
+    };
+    function updateAddShapePanels() {
+      var v = addType.value;
+      for (var key in addFieldGroups) {
+        addFieldGroups[key].classList.add("hidden");
+      }
+      if (v === "cube") addFieldGroups.cube.classList.remove("hidden");
+      else if (v === "sphere") addFieldGroups.sphere.classList.remove("hidden");
+      else if (v === "pyramid") addFieldGroups.pyramid.classList.remove("hidden");
+      else if (v === "cylinder") addFieldGroups.cylinder.classList.remove("hidden");
+      else if (v === "torus") addFieldGroups.torus.classList.remove("hidden");
+    }
+    addType.addEventListener("change", updateAddShapePanels);
+    updateAddShapePanels();
 
     canvas.addEventListener("click", function () {
       window.allowMovement = !window.allowMovement;
@@ -475,6 +613,9 @@
       if (k === 1) return "Box";
       if (k === 2) return "Sphere";
       if (k === 3) return "CSG";
+      if (k === 4) return "Pyramid";
+      if (k === 5) return "Cylinder";
+      if (k === 6) return "Torus";
       return "Object";
     }
 
@@ -484,13 +625,13 @@
       def.value = "";
       def.textContent = "— None —";
       el.appendChild(def);
-      var counts = { 1: 0, 2: 0, 3: 0 };
+      var kcounts = {};
       for (var i = 0; i < n; i++) {
         var k = Module._getObjectKind(i);
-        counts[k] = (counts[k] || 0) + 1;
+        kcounts[k] = (kcounts[k] || 0) + 1;
         var opt = document.createElement("option");
         opt.value = String(i);
-        opt.textContent = kindLabel(k) + " #" + counts[k] + " (index " + i + ")";
+        opt.textContent = kindLabel(k) + " #" + kcounts[k] + " (index " + i + ")";
         el.appendChild(opt);
       }
       if (currentIdx >= 0 && currentIdx < n) el.value = String(currentIdx);
@@ -533,17 +674,19 @@
       var kind = sel >= 0 ? Module._getObjectKind(sel) : 0;
       var boxBlock = document.getElementById("resizeBoxFields");
       var sphBlock = document.getElementById("resizeSphereFields");
+      var pyrBlock = document.getElementById("resizePyramidFields");
+      var cylBlock = document.getElementById("resizeCylinderFields");
+      var torBlock = document.getElementById("resizeTorusFields");
       var unavail = document.getElementById("resizeUnavailable");
+      [boxBlock, sphBlock, pyrBlock, cylBlock, torBlock].forEach(function (el) {
+        el.classList.add("hidden");
+      });
       if (sel < 0 || kind === 0) {
-        boxBlock.classList.add("hidden");
-        sphBlock.classList.add("hidden");
         unavail.classList.remove("hidden");
-        unavail.textContent = "Select a box or sphere to edit its dimensions.";
+        unavail.textContent = "Select a primitive to edit its dimensions.";
         return;
       }
       if (kind === 3) {
-        boxBlock.classList.add("hidden");
-        sphBlock.classList.add("hidden");
         unavail.classList.remove("hidden");
         unavail.textContent = "CSG mesh: resizing is not supported. Add a new primitive if needed.";
         return;
@@ -551,16 +694,31 @@
       unavail.classList.add("hidden");
       if (kind === 1) {
         boxBlock.classList.remove("hidden");
-        sphBlock.classList.add("hidden");
         document.getElementById("resW").value = String(Module._getSelectedBoxWidth());
         document.getElementById("resH").value = String(Module._getSelectedBoxHeight());
         document.getElementById("resD").value = String(Module._getSelectedBoxDepth());
       } else if (kind === 2) {
-        boxBlock.classList.add("hidden");
         sphBlock.classList.remove("hidden");
         document.getElementById("resRad").value = String(Module._getSelectedSphereRadius());
         document.getElementById("resSegW").value = String(Module._getSelectedSphereWidthSegments());
         document.getElementById("resSegH").value = String(Module._getSelectedSphereHeightSegments());
+      } else if (kind === 4) {
+        pyrBlock.classList.remove("hidden");
+        document.getElementById("resPyrSide").value = String(Module._getSelectedPyramidSide());
+        document.getElementById("resPyrH").value = String(Module._getSelectedPyramidHeight());
+      } else if (kind === 5) {
+        cylBlock.classList.remove("hidden");
+        document.getElementById("resCylRb").value = String(Module._getSelectedCylinderRadiusBottom());
+        document.getElementById("resCylRt").value = String(Module._getSelectedCylinderRadiusTop());
+        document.getElementById("resCylH").value = String(Module._getSelectedCylinderHeight());
+        document.getElementById("resCylRs").value = String(Module._getSelectedCylinderRadialSegments());
+        document.getElementById("resCylHs").value = String(Module._getSelectedCylinderHeightSegments());
+      } else if (kind === 6) {
+        torBlock.classList.remove("hidden");
+        document.getElementById("resTorMaj").value = String(Module._getSelectedTorusMajorRadius());
+        document.getElementById("resTorMin").value = String(Module._getSelectedTorusMinorRadius());
+        document.getElementById("resTorRs").value = String(Module._getSelectedTorusRadialSegments());
+        document.getElementById("resTorTs").value = String(Module._getSelectedTorusTubularSegments());
       }
     }
 
@@ -579,13 +737,13 @@
         syncResizePanel();
         return;
       }
-      var counts = { 1: 0, 2: 0, 3: 0 };
+      var counts2 = {};
       for (var i = 0; i < n; i++) {
         var k = Module._getObjectKind(i);
-        counts[k] = (counts[k] || 0) + 1;
+        counts2[k] = (counts2[k] || 0) + 1;
         var opt = document.createElement("option");
         opt.value = String(i);
-        opt.textContent = kindLabel(k) + " #" + counts[k] + " (index " + i + ")";
+        opt.textContent = kindLabel(k) + " #" + counts2[k] + " (index " + i + ")";
         objectSelect.appendChild(opt);
       }
       if (sel >= 0 && sel < n) objectSelect.value = String(sel);
@@ -681,12 +839,32 @@
             var d = parseFloat(document.getElementById("addD").value);
             if (!(w > 0 && h > 0 && d > 0)) return;
             Module._addCube(w, h, d);
-          } else {
+          } else if (addType.value === "sphere") {
             var rad = parseFloat(document.getElementById("addR").value);
             var sw = parseInt(document.getElementById("addSegW").value, 10);
             var sh = parseInt(document.getElementById("addSegH").value, 10);
             if (!(rad > 0)) return;
             Module._addSphere(rad, sw, sh);
+          } else if (addType.value === "pyramid") {
+            var ps = parseFloat(document.getElementById("addPyrSide").value);
+            var ph = parseFloat(document.getElementById("addPyrH").value);
+            if (!(ps > 0 && ph > 0)) return;
+            Module._addPyramid(ps, ph);
+          } else if (addType.value === "cylinder") {
+            var rb = parseFloat(document.getElementById("addCylRb").value);
+            var rt = parseFloat(document.getElementById("addCylRt").value);
+            var ch = parseFloat(document.getElementById("addCylH").value);
+            var crs = parseInt(document.getElementById("addCylRs").value, 10);
+            var chs = parseInt(document.getElementById("addCylHs").value, 10);
+            if (!(rb > 0 && rt > 0 && ch > 0)) return;
+            Module._addCylinder(rb, rt, ch, crs, chs);
+          } else if (addType.value === "torus") {
+            var maj = parseFloat(document.getElementById("addTorMaj").value);
+            var minr = parseFloat(document.getElementById("addTorMin").value);
+            var trs = parseInt(document.getElementById("addTorRs").value, 10);
+            var tts = parseInt(document.getElementById("addTorTs").value, 10);
+            if (!(maj > 0 && minr > 0)) return;
+            Module._addTorus(maj, minr, trs, tts);
           }
           refreshObjectList();
         });
@@ -704,6 +882,29 @@
           var sw = parseInt(document.getElementById("resSegW").value, 10);
           var sh = parseInt(document.getElementById("resSegH").value, 10);
           if (r > 0) Module._resizeSelectedSphere(r, sw, sh);
+          refreshObjectList();
+        });
+        document.getElementById("btnApplyPyramidResize").addEventListener("click", function () {
+          var s = parseFloat(document.getElementById("resPyrSide").value);
+          var h = parseFloat(document.getElementById("resPyrH").value);
+          if (s > 0 && h > 0) Module._resizeSelectedPyramid(s, h);
+          refreshObjectList();
+        });
+        document.getElementById("btnApplyCylinderResize").addEventListener("click", function () {
+          var rb = parseFloat(document.getElementById("resCylRb").value);
+          var rt = parseFloat(document.getElementById("resCylRt").value);
+          var h = parseFloat(document.getElementById("resCylH").value);
+          var rs = parseInt(document.getElementById("resCylRs").value, 10);
+          var hs = parseInt(document.getElementById("resCylHs").value, 10);
+          if (rb > 0 && rt > 0 && h > 0) Module._resizeSelectedCylinder(rb, rt, h, rs, hs);
+          refreshObjectList();
+        });
+        document.getElementById("btnApplyTorusResize").addEventListener("click", function () {
+          var maj = parseFloat(document.getElementById("resTorMaj").value);
+          var minr = parseFloat(document.getElementById("resTorMin").value);
+          var rs = parseInt(document.getElementById("resTorRs").value, 10);
+          var ts = parseInt(document.getElementById("resTorTs").value, 10);
+          if (maj > 0 && minr > 0) Module._resizeSelectedTorus(maj, minr, rs, ts);
           refreshObjectList();
         });
 


### PR DESCRIPTION
## Summary
- **Primitives** follow Three.js r162 `BoxGeometry`, `SphereGeometry`, `CylinderGeometry`, and `TorusGeometry` (topology and indexing).
- **New**: cylinder and torus with `rebuildGeometry`, factory helpers, and **WASM/JS exports**; demo HTML updated.
- **CSG**: `toMesh()` uses **ear-clipping** for non-triangle BSP polygons, **matrix snapshot** for `ThreeBSP`, improved **plane split** numerics, adjusted **EPSILON**, removed **string-based vertex merge** for output meshes.

## Notes
- Rebuild with `./compileWasm.sh` before testing `wasmbuild/*.js` / `*.wasm` (gitignored).
- **Pyramid** remains a custom equilateral base (not `TetrahedronGeometry`).

## Test
- Add solids, set operands A/B, run union / difference / intersection; try cylinder + cube/sphere after hard refresh.

Co-authored-by: Cursor <cursor@cursor.com>

Made with [Cursor](https://cursor.com)