### PR TITLE
Z-up grid: orbit camera, default framing, Three.js primitive alignment

### DIFF
--- a/src/camera/orbit_camera.cpp
+++ b/src/camera/orbit_camera.cpp
@@ -20,8 +20,9 @@ void OrbitCamera::Spherical::setFromOffset(glm::vec3 const &v)
 {
   float const len = glm::length(v);
   radius = std::max(len, 1e-6f);
-  theta = std::atan2(v.x, v.z);
-  phi = std::acos(std::clamp(v.y / radius, -1.0f, 1.0f));
+  /** Azimuth in XY around +Z; polar angle from +Z (grid normal). */
+  theta = std::atan2(v.y, v.x);
+  phi = std::acos(std::clamp(v.z / radius, -1.0f, 1.0f));
   makeSafe();
 }
 
@@ -35,9 +36,9 @@ glm::vec3 OrbitCamera::Spherical::cartesian() const
 {
   float const sp = std::sin(phi);
   return glm::vec3(
+      radius * sp * std::cos(theta),
       radius * sp * std::sin(theta),
-      radius * std::cos(phi),
-      radius * sp * std::cos(theta));
+      radius * std::cos(phi));
 }
 
 OrbitCamera::OrbitCamera(glm::vec3 const &worldPosition, glm::vec3 const &target)
@@ -52,7 +53,7 @@ OrbitCamera::OrbitCamera(glm::vec3 const &worldPosition, glm::vec3 const &target
 
 glm::mat4 OrbitCamera::calculateViewMatrix() const
 {
-  return glm::lookAt(position_, target_, glm::vec3(0.0f, 1.0f, 0.0f));
+  return glm::lookAt(position_, target_, glm::vec3(0.0f, 0.0f, 1.0f));
 }
 
 bool OrbitCamera::update(GLfloat deltaTime)
@@ -129,7 +130,7 @@ void OrbitCamera::dolly(float distance, bool enableTransition)
 void OrbitCamera::truck(float x, float y, bool enableTransition)
 {
   glm::vec3 const forward = glm::normalize(target_ - position_);
-  glm::vec3 worldUp(0.0f, 1.0f, 0.0f);
+  glm::vec3 worldUp(0.0f, 0.0f, 1.0f);
   glm::vec3 right = glm::normalize(glm::cross(forward, worldUp));
   if (glm::length(right) < 1e-6f)
     right = glm::vec3(1.0f, 0.0f, 0.0f);

--- a/src/camera/orbit_camera.h
+++ b/src/camera/orbit_camera.h
@@ -10,7 +10,11 @@
 class OrbitCamera
 {
 public:
-  explicit OrbitCamera(glm::vec3 const &worldPosition = glm::vec3(0.0f, 0.0f, 2.4f),
+  /**
+   * Default eye: above the default BaseGrid (±10 in X/Y), diagonal in XY, tilted from +Z so the
+   * full grid is in frame at ~48° vertical FOV (adjust radius if grid size changes).
+   */
+  explicit OrbitCamera(glm::vec3 const &worldPosition = glm::vec3(13.5f, 13.5f, 15.5f),
                        glm::vec3 const &target = glm::vec3(0.0f));
 
   glm::mat4 calculateViewMatrix() const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,7 +48,16 @@ static int g_boolOperandB{-1};
 Shader litShader;
 Shader lineShader;
 BaseGridRenderer g_baseGrid;
-OrbitCamera orbitCamera(glm::vec3(0.0f, 0.0f, 2.4f), glm::vec3(0.0f));
+OrbitCamera orbitCamera(glm::vec3(13.5f, 13.5f, 15.5f), glm::vec3(0.0f));
+
+namespace
+{
+/** Three.js meshes use +Y as cylinder/box height; +90° X maps height onto +Z (grid / world up). */
+inline glm::vec3 alignThreeYUpToWorldZ()
+{
+	return glm::vec3(glm::radians(90.0f), 0.0f, 0.0f);
+}
+} // namespace
 GLfloat deltaTime{0.0f};
 GLfloat lastTime{0.0f};
 int loops{0};
@@ -187,7 +196,8 @@ void CreateShaders()
 {
 	litShader.CreateFromString(vLit, fLit);
 	lineShader.CreateFromString(vLine, fLine);
-	g_lightDirWorld = glm::normalize(glm::vec3(0.42f, 0.85f, 0.35f));
+	/** Mostly downward / −Z-ish lighting so Z-up solids read clearly. */
+	g_lightDirWorld = glm::normalize(glm::vec3(0.28f, 0.22f, 0.92f));
 }
 
 void emcmainloop(void *mainLoopArg);
@@ -310,7 +320,7 @@ void addCube(float width, float height, float depth)
 	GLfloat const d = std::max(1e-4f, depth);
 	auto cube = createBox(BoxDimensions{w, h, d});
 	cube->setSolidColor(glm::vec3(0.92f, 0.48f, 0.18f));
-	cube->rotate(glm::vec3(0.0f, glm::radians(45.0f), 0.0f));
+	cube->rotate(alignThreeYUpToWorldZ());
 	cube->computeThreeBSP();
 	meshList.push_back(cube);
 	meshObjectKinds.push_back(1);
@@ -349,6 +359,8 @@ void addCylinder(float radiusBottom, float radiusTop, float height, int radialSe
 			CylinderDimensions{std::max(1e-4f, radiusBottom), std::max(1e-4f, radiusTop), std::max(1e-4f, height)},
 			CylinderParameters{rseg, hseg});
 	cyl->setSolidColor(glm::vec3(0.24f, 0.78f, 0.45f));
+	cyl->rotate(alignThreeYUpToWorldZ());
+	cyl->computeThreeBSP();
 	meshList.push_back(cyl);
 	meshObjectKinds.push_back(5);
 	g_selectedIndex = static_cast<int>(meshList.size()) - 1;
@@ -362,6 +374,8 @@ void addCone(float radius, float height, int radialSeg, int heightSeg)
 			CylinderDimensions{std::max(1e-4f, radius), 0.0f, std::max(1e-4f, height)},
 			CylinderParameters{rseg, hseg});
 	cone->setSolidColor(glm::vec3(0.95f, 0.42f, 0.28f));
+	cone->rotate(alignThreeYUpToWorldZ());
+	cone->computeThreeBSP();
 	meshList.push_back(cone);
 	meshObjectKinds.push_back(7);
 	g_selectedIndex = static_cast<int>(meshList.size()) - 1;


### PR DESCRIPTION
Contributes Z-up scene alignment and camera improvements from the fork. See individual commits on develop for details (orbit +Z, grid-wide default view, box/cylinder/cone BSP alignment).

Made with [Cursor](https://cursor.com)